### PR TITLE
Enhance regex to recognize variables

### DIFF
--- a/ctagsrc
+++ b/ctagsrc
@@ -99,9 +99,9 @@
 --regex-javascript=/\/\/[ \t]*\(HACK\)[ \t]*:*\(.*\)/\1/T,Tag,Tags/b
 --regex-javascript=/\/\/[ \t]*\(XXX\)[ \t]*:*\(.*\)/\1/T,Tag,Tags/b
 
---regex-javascript=/^[ \t]*var[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[0-9\"'\/]/\1/V,Variable,Variables/b
---regex-javascript=/^[ \t]*let[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[0-9\"'\/]/\1/V,Variable,Variables/b
---regex-javascript=/^[ \t]*const[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[0-9\"'\/]/\1/V,Variable,Variables/b
+--regex-javascript=/^[ \t]*var[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[A-Za-z0-9_$\`\"'\/]/\1/V,Variable,Variables/b
+--regex-javascript=/^[ \t]*let[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[A-Za-z0-9_$\`\"'\/]/\1/V,Variable,Variables/b
+--regex-javascript=/^[ \t]*const[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*[A-Za-z0-9_$\`\"'\/]/\1/V,Variable,Variables/b
 --regex-javascript=/^[ \t]*var[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*new/\1/V,Variable,Variables/b
 --regex-javascript=/^[ \t]*let[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*new/\1/V,Variable,Variables/b
 --regex-javascript=/^[ \t]*const[ \t]\{1,\}\([A-Za-z0-9_$]\{1,\}\)[ \t]*=[ \t]*new/\1/V,Variable,Variables/b


### PR DESCRIPTION
It looks like when assigning another variable to another it's not being recognised by `ctags`. Also when any string is set by back-tick, or set by string template, it's not being recognised too.

Given the js file below

```js
const year = 1984
const month = `october`
const day = '21'
const birthday = year + 'y' + month + 'm' + day + 'd'
```

we can use the command bellow to test it out:

```sh
ctags  -f - --format=2 --excmd=pattern --fields=nks <filename>
```



### BEFORE

As it is today, we have the following output from `ctags`

```
day	test-test.js	/^const day = '21'$/;"	V	line:3
year	test-test.js	/^const year = 1984$/;"	V	line:1
```

### AFTER

After applying this enhancement, we start getting the following output

```
birthday	test-test.js	/^const birthday = year + 'y' + month + 'm' + day + 'd'$/;"	V	line:4
day	test-test.js	/^const day = '21'$/;"	V	line:3
month	test-test.js	/^const month = `october`$/;"	V	line:2
year	test-test.js	/^const year = 1984$/;"	V	line:1
```